### PR TITLE
Initialise counters w/o using CounterVec#Set

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,22 +1,3 @@
-
-# Gopkg.toml example
-#
+# Gopkg.toml
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
 # for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
-

--- a/promrus.go
+++ b/promrus.go
@@ -22,7 +22,7 @@ func NewPrometheusHook() (*PrometheusHook, error) {
 	}, []string{"level"})
 	// Initialise counters for all supported levels:
 	for _, level := range supportedLevels {
-		counterVec.WithLabelValues(level.String()).Set(0)
+		counterVec.WithLabelValues(level.String())
 	}
 	// Try to unregister the counter vector, in case already registered for some reason,
 	// e.g. double initialisation/configuration done by mistake by the end-user.


### PR DESCRIPTION
Steps followed:

- ~added constraint to `Gopkg.toml`~ (removed from PR):

        [[constraint]]
            name = "github.com/prometheus/client_golang"
            version = "0.9.0-pre1"

- ran:

        $ dep ensure && dep prune

- modified initialisation of counters.


This fixes #3.