### PR TITLE
Add option to override supported levels

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,25 @@
+package promrus
+
+import "github.com/sirupsen/logrus"
+
+type options struct {
+	levels []logrus.Level
+}
+
+var defaultLevels = []logrus.Level{logrus.DebugLevel, logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel}
+
+func newDefaultOptions() options {
+	return options{
+		levels: defaultLevels,
+	}
+}
+
+type Option func(*options)
+
+// ForLevels allows overriding the default levels which are counted. All other levels are not counted.
+// The default levels are DebugLevel, InfoLevel, WarnLevel, & ErrorLevel.
+func ForLevels(levels ...logrus.Level) Option {
+	return func(opts *options) {
+		opts.levels = levels
+	}
+}


### PR DESCRIPTION
This pull request uses the functional optional pattern to be backward compatible and allow callers to override which levels metrics are emitted for.

The goal of this change to resolve two open issues:
- https://github.com/weaveworks/promrus/issues/13
- https://github.com/weaveworks/promrus/issues/16