### PR TITLE
Default supported levels to count for all logrus levels

### DIFF
--- a/promrus.go
+++ b/promrus.go
@@ -10,7 +10,7 @@ type PrometheusHook struct {
 	counterVec *prometheus.CounterVec
 }
 
-var supportedLevels = []logrus.Level{logrus.DebugLevel, logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel}
+var supportedLevels = logrus.AllLevels
 
 // NewPrometheusHook creates a new instance of PrometheusHook which exposes Prometheus counters for various log levels.
 // Contrarily to MustNewPrometheusHook, it returns an error to the caller in case of issue.


### PR DESCRIPTION
There are a few logrus levels that have been added and are not supported by default today:

https://github.com/sirupsen/logrus/blob/v1.8.1/logrus.go#L81-L89

This should keep the two lists in lock-step no matter which combinations of versions between logrus and promrus are used.

At least one of these has been submitted as an issue: https://github.com/weaveworks/promrus/issues/13.

Note: This will create a merge conflict with https://github.com/weaveworks/promrus/pull/19 so whichever one merges first, the other will need to be rebased (I am happy to do that). I wanted to submit them separately as they seemed like relatively separate concerns.